### PR TITLE
Docker bind & volume mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+num.txt

--- a/README.md
+++ b/README.md
@@ -53,11 +53,31 @@ docker build -t static-app .
 # Port exposed to host is 8080. Internal port used is 80. And nginx uses 80 as the default port
 docker run --init --rm -p 8080:80 static-app
 
+# Using docker bind mount. Below command mounts the /build directory inside nginx html directory
+docker run --mount type=bind,source="$(pwd)"/build,target=/usr/share/nginx/html -p 8080:80 nginx:1.17-alpine
 
 ```
 
-## Todos?
+## Docker bind
 
-- Explain below docker run command attributes
-  - docker run `--init`
-  - docker run `--rm`
+<u>Bind mount</u>
+
+- Bind mount are works great when you need to share data between host and container.
+- Build image `docker build --tag=incrementor-bind .`
+  - New image create with the tag name `incrementor-bind`
+- Run container `docker run --rm --env DATA_PATH=data/num.txt --mount type=bind,source="$(pwd)"/incrementor-data,target=/src/data incrementor-bind`
+
+<u>Volume mount</u>
+
+- Using bind volumes containers can maintain states between runs.
+- Build image `docker build --tag=incrementor-volume .`
+- Run container `docker run --rm --env DATA_PATH=/data/num.txt --mount type=volume,src=incrementor-data,target=/data incrementor-volume`
+
+## Explain all docker command attribute used
+
+<u>Try all example commands within this directory</u>
+
+- `--env` Passes process environment variable. For example `docker run --rm --env DATA_PATH=data/num.txt --mount type=bind,source="$(pwd)"/incrementor-data,target=/src/data incrementor-bind`. Here `DATA_PATH` is the process environment variable passed. Node application can use this data by `process.env.DATA_PATH`
+- `--rm` Deletes the container after exiting the process. Try running any container with and without this flag to see the difference. For example `docker run --rm --env DATA_PATH=data/num.txt --mount type=bind,source="$(pwd)"/incrementor-data,target=/src/data incrementor-bind` deletes the container after exiting the run process, but `docker run --env DATA_PATH=data/num.txt --mount type=bind,source="$(pwd)"/incrementor-data,target=/src/data incrementor-bind` doesn't deletes the container after exiting the process
+- `src` or `source` mount source directory i.e `docker run --rm --env DATA_PATH=/data/num.txt --mount type=volume,src=incrementor-data,target=/data incrementor-volume` or `docker run --rm --env DATA_PATH=/data/num.txt --mount type=volume,source=incrementor-data,target=/data incrementor-volume`
+- `--init` Gracefully exits node process where listen is used

--- a/docker-mount/.dockerignore
+++ b/docker-mount/.dockerignore
@@ -1,0 +1,1 @@
+incrementor-data/

--- a/docker-mount/Dockerfile
+++ b/docker-mount/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:12-alpine
+COPY --chown=node:node . /src
+WORKDIR /src
+CMD ["node", "index.js"]

--- a/docker-mount/incrementor-data/sample.txt
+++ b/docker-mount/incrementor-data/sample.txt
@@ -1,0 +1,1 @@
+This is a sample text file

--- a/docker-mount/index.js
+++ b/docker-mount/index.js
@@ -1,0 +1,19 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const dataPath = path.join(process.env.DATA_PATH || './data.txt');
+
+fs.readFile(dataPath)
+  .then((buffer) => {
+    const data = buffer.toString();
+    console.log(data);
+    writeTo(+data + 1);
+  })
+  .catch((e) => {
+    console.log('file not found, writing 0 to a new file');
+    writeTo(0);
+  });
+
+const writeTo = (data) => {
+  fs.writeFile(dataPath, data.toString()).catch(console.error);
+};


### PR DESCRIPTION
# Docker bind & volume mounts

> Explain docker bind & volume mounts with example 

Sample application created to increment the counter. And the counter persist across multiple docker runs. This is being mounted to the application by two different types bind & volume. To see it in action try the run command multiple times for both the context bind & volume.

## Bind mount
```shell

docker build --tag=incrementor-bind .
# bind mount
docker run --rm --env DATA_PATH=data/num.txt --mount type=bind,source="$(pwd)"/incrementor-data,target=/src/data incrementor-bind

```
<img width="1655" alt="Screenshot 2020-05-30 at 9 00 30 AM" src="https://user-images.githubusercontent.com/802163/83318621-2599a400-a254-11ea-87cd-dca25eb75c99.png">


## Volume mount
```shell

docker build --tag=incrementor-volume .
# volume mount
docker run --rm --env DATA_PATH=/data/num.txt --mount type=volume,src=incrementor-data,target=/data incrementor-volume

```
<img width="1551" alt="Screenshot 2020-05-30 at 9 05 41 AM" src="https://user-images.githubusercontent.com/802163/83318704-d56f1180-a254-11ea-80f0-1d0ef1fdeb66.png">

